### PR TITLE
Exclude tests directory from classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,10 @@
     "autoload": {
         "psr-4": {
             "Acrobat\\Bundle\\RecaptchaBundle\\": ""
-        }
+        },
+        "exclude-from-classmap": [
+            "**/Tests/"
+        ]
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Excludes tests from the composer classmap as they are not required to be included in it. See https://getcomposer.org/doc/04-schema.md#exclude-files-from-classmaps